### PR TITLE
Bring documentation up-to-date for GPT-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The `wc` utility counts words or characters. The `gptwc` utility functions similarly but counts tokens.
 Tokens are smaller than words but larger than characters, and are a more compact representation of text used by large language models.
 
-Use `gptwc` to check the number of tokens in a string, in order to remain under the token limit (eg. 4097) for your large language model API. Uses `tiktoken`.
+Use `gptwc` to check the number of tokens in a string, in order to remain under the token limit for your large language model API. Uses [`tiktoken`](https://github.com/openai/tiktoken).
 
 
 ## Installation
@@ -11,14 +11,14 @@ Use `gptwc` to check the number of tokens in a string, in order to remain under 
 $ pip install gptwc
 
 $ echo "Simple is better than complex." | gptwc
-7
+6
 ```
 
 ## Example Usage
 
 ```
-$ cat LICENSE  | gptwc
-257
+$ cat LICENSE | gptwc
+200
 $ cat LICENSE | wc -c
 1059
 $ cat LICENSE | wc -w
@@ -29,12 +29,12 @@ $ curl -s 'https://gist.githubusercontent.com/phillipj/4944029/raw/75ba2243dd5ec
 26470
 
 curl -s 'https://gist.githubusercontent.com/phillipj/4944029/raw/75ba2243dd5ec2875f629bf5d79f6c1e4b5a8b46/alice_in_wonderland.txt' | gptwc
-40085
+38071
 
 
-$ cat LICENSE | gptwc --model text-davinci-003
-257
-$ cat LICENSE | gptwc --model gpt-3.5-turbo
+$ cat LICENSE | gptwc --model o200k_base
+200
+$ cat LICENSE | gptwc --model cl100k_base
 201
 
 
@@ -56,51 +56,11 @@ positional arguments:
 options:
   -h, --help       show this help message and exit
   --files0-from F  Read input from the files specified by NUL-terminated names in file F
-  --model MODEL    Model name to use for tokenization (default: gpt-4)
+  --model MODEL    Encoding or model to use for tokenization (default: o200k_base, used by GPT-5 and GPT-4o)
   -c, --clipboard  Read input from the system clipboard
   --version        show program's version number and exit
 ```
 
 ## Which Tokenizer Does Each Model Use?
 
-From [tiktoken/model.py](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py)
-
-```
-"gpt-4o": "o200k_base",
-"gpt-4": "cl100k_base",
-"gpt-3.5-turbo": "cl100k_base",
-"text-embedding-ada-002": "cl100k_base",
-
-"text-davinci-003": "p50k_base",
-"text-davinci-002": "p50k_base",
-"code-davinci-002": "p50k_base",
-"code-davinci-001": "p50k_base",
-"code-cushman-002": "p50k_base",
-"code-cushman-001": "p50k_base",
-"davinci-codex": "p50k_base",
-"cushman-codex": "p50k_base",
-
-"text-davinci-001": "r50k_base",
-"text-curie-001": "r50k_base",
-"text-babbage-001": "r50k_base",
-"text-ada-001": "r50k_base",
-"davinci": "r50k_base",
-"curie": "r50k_base",
-"babbage": "r50k_base",
-"ada": "r50k_base",
-"text-similarity-davinci-001": "r50k_base",
-"text-similarity-curie-001": "r50k_base",
-"text-similarity-babbage-001": "r50k_base",
-"text-similarity-ada-001": "r50k_base",
-"text-search-davinci-doc-001": "r50k_base",
-"text-search-curie-doc-001": "r50k_base",
-"text-search-babbage-doc-001": "r50k_base",
-"text-search-ada-doc-001": "r50k_base",
-"code-search-babbage-code-001": "r50k_base",
-"code-search-ada-code-001": "r50k_base",
-
-"text-davinci-edit-001": "p50k_edit",
-"code-davinci-edit-001": "p50k_edit",
-
-"gpt2": "gpt2",
-```
+See [tiktoken/model.py](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py) for an up-to-date list.

--- a/gptwc/gptwc.py
+++ b/gptwc/gptwc.py
@@ -19,7 +19,7 @@ def main():
     parser = argparse.ArgumentParser(description="Count tokens in text files using OpenAI's tiktoken library.")
     parser.add_argument("files", metavar="FILE", nargs="*", type=Path, help="Text files to count tokens in")
     parser.add_argument("--files0-from", metavar="F", type=Path, help="Read input from the files specified by NUL-terminated names in file F")
-    parser.add_argument("--model", default="o200k_base", metavar="MODEL", help="Encoding or model to use for tokenization (default: o200k_base, used by GPT-4o. Use cl100k_base for GPT-3.5 and GPT-4)")
+    parser.add_argument("--model", default="o200k_base", metavar="MODEL", help="Encoding or model to use for tokenization (default: o200k_base, used by GPT-5 and GPT-4o)")
     parser.add_argument("-c", "--clipboard", action="store_true", help="Read input from the system clipboard")
     parser.add_argument("--version", action="version", version="%(prog)s 1.2.6")
     args = parser.parse_args()


### PR DESCRIPTION
GPT-5 appears to still use [the same tokenizer](https://github.com/openai/tiktoken/blob/2ab6d3706d557b560b200be48e6a32324682c9a3/tiktoken/model.py#L12). So this is purely a documentation change, to make it clear that you're getting the GPT-5 token count.